### PR TITLE
Trivialestimator (Approach 3)

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
@@ -58,6 +58,24 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// Create a new estimator chain, by appending another estimator to the end of this estimator.
+        /// </summary>
+        public static TrivialEstimatorChain<TTrans> Append<TTrans, TTrans2>(
+            this TrivialEstimator<TTrans2> start, TrivialEstimator<TTrans> estimator,
+            TransformerScope scope = TransformerScope.Everything)
+            where TTrans : class, ITransformer
+            where TTrans2 : class, ITransformer
+        {
+            Contracts.CheckValue(start, nameof(start));
+            Contracts.CheckValue(estimator, nameof(estimator));
+
+            if (start is TrivialEstimator<ITransformer> est)
+                return est.Append(estimator, scope);
+
+            return new TrivialEstimatorChain<ITransformer>().Append(start).Append(estimator, scope);
+        }
+
+        /// <summary>
         /// Append a 'caching checkpoint' to the estimator chain. This will ensure that the downstream estimators will be trained against
         /// cached data. It is helpful to have a caching checkpoint before trainers that take multiple data passes.
         /// </summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
@@ -19,25 +19,27 @@ namespace Microsoft.ML.Data
         [BestFriend]
         private protected readonly IHost Host;
         [BestFriend]
-        private protected readonly TTransformer Transformer;
+        internal readonly TTransformer Transformer;
 
         [BestFriend]
         private protected TrivialEstimator(IHost host, TTransformer transformer)
         {
             Contracts.AssertValue(host);
-
             Host = host;
             Host.CheckValue(transformer, nameof(transformer));
             Transformer = transformer;
         }
 
-        public TTransformer Fit(IDataView input)
+        public virtual TTransformer Fit(IDataView input)
         {
             Host.CheckValue(input, nameof(input));
             // Validate input schema.
             Transformer.GetOutputSchema(input.Schema);
             return Transformer;
         }
+
+        public virtual IDataView Transform(IDataView input)
+            => Transformer.Transform(input);
 
         public abstract SchemaShape GetOutputSchema(SchemaShape inputSchema);
     }

--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ML.Data
     /// Concrete implementations still have to provide the schema propagation mechanism, since
     /// there is no easy way to infer it from the transformer.
     /// </summary>
-    public abstract class TrivialEstimator<TTransformer> : IEstimator<TTransformer>
+    public abstract class TrivialEstimator<TTransformer> : IEstimator<TTransformer>, ICanSaveModel
         where TTransformer : class, ITransformer
     {
         [BestFriend]
@@ -42,5 +42,9 @@ namespace Microsoft.ML.Data
             => Transformer.Transform(input);
 
         public abstract SchemaShape GetOutputSchema(SchemaShape inputSchema);
+
+        // REVIEW: Possibly? Not sure if we want this to be saveable... IF we want to keep need to test
+        void ICanSaveModel.Save(ModelSaveContext ctx)
+            => Transformer.Save(ctx);
     }
 }

--- a/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
+++ b/src/Microsoft.ML.Data/Model/ModelOperationsCatalog.cs
@@ -296,5 +296,25 @@ namespace Microsoft.ML
             return transformer.CreatePredictionEngine<TSrc, TDst>(_env, false,
                 DataViewConstructionUtils.GetSchemaDefinition<TSrc>(_env, inputSchema));
         }
+
+        // REVIEW: Do we want this? If so need to test
+        public PredictionEngine<TSrc, TDst> CreatePredictionEngine<TSrc, TDst, TTrans>(TrivialEstimator<TTrans> trivialEstimator,
+            bool ignoreMissingColumns = true, SchemaDefinition inputSchemaDefinition = null, SchemaDefinition outputSchemaDefinition = null)
+            where TSrc : class
+            where TDst : class, new()
+            where TTrans : class, ITransformer
+        {
+            return trivialEstimator.Transformer.CreatePredictionEngine<TSrc, TDst>(_env, ignoreMissingColumns, inputSchemaDefinition, outputSchemaDefinition);
+        }
+
+        // REVIEW: Do we want this? If so need to test
+        public PredictionEngine<TSrc, TDst> CreatePredictionEngine<TSrc, TDst, TTrans>(TrivialEstimator<TTrans> trivialEstimator, DataViewSchema inputSchema)
+            where TSrc : class
+            where TDst : class, new()
+            where TTrans : class, ITransformer
+        {
+            return trivialEstimator.Transformer.CreatePredictionEngine<TSrc, TDst>(_env, false,
+                DataViewConstructionUtils.GetSchemaDefinition<TSrc>(_env, inputSchema));
+        }
     }
 }

--- a/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
+++ b/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Data;
+using Microsoft.ML.TestFramework;
+using Microsoft.ML.Transforms;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.Tests
+{
+    public class TrivialEstimatorTransformerTests : BaseTestClass
+    {
+        public TrivialEstimatorTransformerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        void SimpleTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "NFL" , Age = 14 },
+                new DataPoint() { Category = "NFL" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLS" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define a TrivialEstimator and Transform data.
+            var transformedData = mlContext.Transforms.CopyColumns("CopyAge", "Age").Transform(data);
+
+            // Inspect output and check that it actually transforms data.
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach(var outDataPoint in outEnum)
+                Assert.True(outDataPoint.CopyAge != 0);
+        }
+
+        [Fact]
+        void TrivialEstimatorChainsTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define a TrivialEstimatorChain by appending two TrivialEstimators.
+            var trivialEstimatorChain = mlContext.Transforms.CopyColumns("CopyAge", "Age")
+                .Append(mlContext.Transforms.CopyColumns("CopyCategory", "Category"));
+
+            // Transform data directly.
+            var transformedData = trivialEstimatorChain.Transform(data);
+
+            // Inspect output and check that it actually transforms data.
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach (var outDataPoint in outEnum)
+            {
+                Assert.True(outDataPoint.CopyAge != 0);
+                Assert.True(outDataPoint.CopyCategory == "MLB");
+            }
+        }
+
+
+        [Fact]
+        void EstimatorChainsTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define same TrivialEstimatorChain by appending two TrivialEstimators.
+            var trivialEstimatorChain = mlContext.Transforms.CopyColumns("CopyAge", "Age")
+                .Append(mlContext.Transforms.CopyColumns("CopyCategory", "Category"));
+            
+            // Check that this is TrivialEstimatorChain and that I can transform data directly.
+            Assert.True(trivialEstimatorChain is TrivialEstimatorChain<ColumnCopyingTransformer>);
+            var transformedData = trivialEstimatorChain.Transform(data);
+
+            // Append a non trivial estimator to the chain.
+            var estimatorChain = trivialEstimatorChain.Append(mlContext.Transforms.Categorical.OneHotEncoding("OneHotAge", "Age"));
+
+            // The below gives an ERROR since the type becomes EstimatorChain as OneHotEncoding is not a trivial estimator. Uncomment to check!
+            //transformedData = estimatorChain.Transform(data);
+            Assert.True(estimatorChain is EstimatorChain<OneHotEncodingTransformer>);
+
+            // Use .Fit() and .Transform() to transform data after training the transform.
+            transformedData = estimatorChain.Fit(data).Transform(data);
+
+            // Check that adding a TrivialEstimator does not bring us back to a TrivialEstimatorChain since we have a trainable transform.
+            var newEstimatorChain = estimatorChain.Append(mlContext.Transforms.CopyColumns("CopyOneHotAge", "OneHotAge"));
+
+            // The below gives an ERROR since the type stays EstimatorChain as there is non trivial estimator in the chain. Uncomment to check!
+            //transformedData = newEstimatorChain.Transform(data);
+            Assert.True(newEstimatorChain is EstimatorChain<ColumnCopyingTransformer>);
+
+            // Use .Fit() and .Transform() to transform data after training the transform.
+            transformedData = newEstimatorChain.Fit(data).Transform(data);
+
+            // Check that the data has actually been transformed
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach (var outDataPoint in outEnum)
+            {
+                Assert.True(outDataPoint.CopyAge != 0);
+                Assert.True(outDataPoint.CopyCategory == "MLB");
+                Assert.NotNull(outDataPoint.OneHotAge);
+                Equals(outDataPoint.CopyOneHotAge, outDataPoint.OneHotAge);
+            }
+
+        }
+
+        [Fact]
+        void TrivialEstimatorChainWorkoutTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            var trivialEstiamtorChain = new TrivialEstimatorChain<ITransformer>();
+            var estimatorChain = new EstimatorChain<ITransformer>();
+
+            var transformedData1 = trivialEstiamtorChain.Transform(data);
+            var transformedData2 = estimatorChain.Fit(data).Transform(data);
+
+            Assert.Equal(transformedData1.Schema.Count, transformedData2.Schema.Count);
+            Assert.True(transformedData1.Schema.Count == 2);
+        }
+
+        private class DataPoint
+        {
+            public string Category { get; set; }
+            public uint Age { get; set; }
+        }
+
+        private class OutDataPoint
+        {
+            public string Category { get; set; }
+            public string CopyCategory { get; set; }
+            public uint Age { get; set; }
+            public uint CopyAge { get; set; }
+            public float[] OneHotAge { get; set; }
+            public float[] CopyOneHotAge { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I am a bit concerned about the fact that we have to .Fit(...) for non trainable transforms. I think it can make ML.NET look really bad! I worked on a solution for the problem...

I tried three approaches:

1. Create a new interface that combines IEstimator and ITransformer:ITrivialEstiamtor<TTransformer> : IEstimator<TTransformer> , ITransformer
2. Make the trivial estimator class implement ITransformer:TrivialEstimator<TTransformer> : IEstimator<TTransformer>, ITransformer
3. Simply add a method .Transform(IDataView input) in  the TrivialEstimator class.

For each one of these the difficult part is making sure that the estimator/transformer chains work properly. So I implemented a TrivialEstiamtorChain that mimics EstimatorChain but on the class TrivialEstimator instead of the interface IEstimator.

For 1. and 2. I did not manage to make it work... When you .Append() two trivialestimators it will just have a difficult time to distinguish whether you want to create a new EstimatorChain or a TransformerChain. 

For 3. I managed to make it work, I think! The .Append() works and will switch to an EstimatorChain as soon as a trainable estimator is added to the pipeline.

Is it fine not having a class/interface that combines ITransformer and IEstimator?


***This PR shows approach 3***