### PR TITLE
TrivialEstimator class become ITransformer (Approach 2)

### DIFF
--- a/src/Microsoft.ML.Data/DataLoadSave/EstimatorChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/EstimatorChain.cs
@@ -8,7 +8,7 @@ using Microsoft.ML.Runtime;
 
 namespace Microsoft.ML.Data
 {
-    /// <summary>
+     /// <summary>
     /// Represents a chain (potentially empty) of estimators that end with a <typeparamref name="TLastTransformer"/>.
     /// If the chain is empty, <typeparamref name="TLastTransformer"/> is always <see cref="ITransformer"/>.
     /// </summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
@@ -63,12 +63,62 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="start">The starting estimator</param>
         /// <param name="env">The host environment to use for caching.</param>
-
         public static EstimatorChain<TTrans> AppendCacheCheckpoint<TTrans>(this IEstimator<TTrans> start, IHostEnvironment env)
             where TTrans : class, ITransformer
         {
             Contracts.CheckValue(start, nameof(start));
             return new EstimatorChain<ITransformer>().Append(start).AppendCacheCheckpoint(env);
+        }
+
+        /// <summary>
+        /// Create a new estimator chain, by appending another estimator to the end of this estimator.
+        /// </summary>
+        public static TrivialEstimatorChain<TTrans> Append<TTrivialEstimatorStart, TTrivialEstimatorNew, TTrans>(
+            this TTrivialEstimatorStart start, TTrivialEstimatorNew estimator,
+            TransformerScope scope = TransformerScope.Everything)
+            where TTrivialEstimatorStart : class, IEstimator<ITransformer>, ITransformer
+            where TTrivialEstimatorNew : class, IEstimator<TTrans>, TTrans
+            where TTrans : class, ITransformer
+        {
+            Contracts.CheckValue(start, nameof(start));
+            Contracts.CheckValue(estimator, nameof(estimator));
+
+            if (start is TrivialEstimatorChain<ITransformer> est)
+                return est.Append(estimator, scope);
+
+            return new TrivialEstimatorChain<ITransformer>().Append(start).Append(estimator, scope);
+        }
+
+        /// <summary>
+        /// Create a new estimator chain, by appending another estimator to the end of this estimator.
+        /// </summary>
+        public static EstimatorChain<TTrans> Append<TTrivialEstimatorStart, TTrans>(
+            this TTrivialEstimatorStart start, IEstimator<TTrans> estimator,
+            TransformerScope scope = TransformerScope.Everything)
+            where TTrivialEstimatorStart : class, IEstimator<ITransformer>, ITransformer
+            where TTrans : class, ITransformer
+        {
+            Contracts.CheckValue(start, nameof(start));
+            Contracts.CheckValue(estimator, nameof(estimator));
+
+            if (start is TrivialEstimatorChain<ITransformer> est)
+                return est.Append(estimator, scope);
+
+            return new EstimatorChain<ITransformer>().Append(start).Append(estimator, scope);
+        }
+
+        /// <summary>
+        /// Append a 'caching checkpoint' to the estimator chain. This will ensure that the downstream estimators will be trained against
+        /// cached data. It is helpful to have a caching checkpoint before trainers that take multiple data passes.
+        /// </summary>
+        /// <param name="start">The starting estimator</param>
+        /// <param name="env">The host environment to use for caching.</param>
+        public static TrivialEstimatorChain<TTrans> AppendCacheCheckpoint<TTrivialEstimator, TTrans>(this TTrivialEstimator start, IHostEnvironment env)
+            where TTrivialEstimator : class, IEstimator<TTrans>, TTrans
+            where TTrans : class, ITransformer
+        {
+            Contracts.CheckValue(start, nameof(start));
+            return new TrivialEstimatorChain<ITransformer>().Append(start).AppendCacheCheckpoint(env);
         }
 
         /// <summary>

--- a/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/EstimatorExtensions.cs
@@ -58,6 +58,23 @@ namespace Microsoft.ML
         }
 
         /// <summary>
+        /// Create a new estimator chain, by appending another estimator to the end of this estimator.
+        /// </summary>
+        public static EstimatorChain<ITransformer> Append<TTrivialEstimator>(
+            this IEstimator<ITransformer> start, TTrivialEstimator estimator,
+            TransformerScope scope = TransformerScope.Everything)
+            where TTrivialEstimator : class, IEstimator<ITransformer>, ITransformer
+        {
+            Contracts.CheckValue(start, nameof(start));
+            Contracts.CheckValue(estimator, nameof(estimator));
+
+            if (start is EstimatorChain<ITransformer> est)
+                return est.Append(estimator, scope);
+
+            return new EstimatorChain<ITransformer>().Append(start).Append(estimator, scope);
+        }
+
+        /// <summary>
         /// Append a 'caching checkpoint' to the estimator chain. This will ensure that the downstream estimators will be trained against
         /// cached data. It is helpful to have a caching checkpoint before trainers that take multiple data passes.
         /// </summary>
@@ -73,12 +90,11 @@ namespace Microsoft.ML
         /// <summary>
         /// Create a new estimator chain, by appending another estimator to the end of this estimator.
         /// </summary>
-        public static TrivialEstimatorChain<TTrans> Append<TTrivialEstimatorStart, TTrivialEstimatorNew, TTrans>(
+        public static TrivialEstimatorChain<ITransformer> Append<TTrivialEstimatorStart, TTrivialEstimatorNew>(
             this TTrivialEstimatorStart start, TTrivialEstimatorNew estimator,
             TransformerScope scope = TransformerScope.Everything)
             where TTrivialEstimatorStart : class, IEstimator<ITransformer>, ITransformer
-            where TTrivialEstimatorNew : class, IEstimator<TTrans>, TTrans
-            where TTrans : class, ITransformer
+            where TTrivialEstimatorNew : class, IEstimator<ITransformer>, ITransformer
         {
             Contracts.CheckValue(start, nameof(start));
             Contracts.CheckValue(estimator, nameof(estimator));
@@ -113,9 +129,8 @@ namespace Microsoft.ML
         /// </summary>
         /// <param name="start">The starting estimator</param>
         /// <param name="env">The host environment to use for caching.</param>
-        public static TrivialEstimatorChain<TTrans> AppendCacheCheckpoint<TTrivialEstimator, TTrans>(this TTrivialEstimator start, IHostEnvironment env)
-            where TTrivialEstimator : class, IEstimator<TTrans>, TTrans
-            where TTrans : class, ITransformer
+        public static TrivialEstimatorChain<ITransformer> AppendCacheCheckpoint<TTrivialEstimator>(this TTrivialEstimator start, IHostEnvironment env)
+            where TTrivialEstimator : class, IEstimator<ITransformer>, ITransformer
         {
             Contracts.CheckValue(start, nameof(start));
             return new TrivialEstimatorChain<ITransformer>().Append(start).AppendCacheCheckpoint(env);

--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimatorChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimatorChain.cs
@@ -25,20 +25,14 @@ namespace Microsoft.ML.Data
             _transformerChain = transformerChain;
         }
 
-        /// <summary>
-        /// Create an empty estimator chain.
-        /// </summary>
         public TrivialEstimatorChain()
         {
-            _host = null;
-            _estimatorChain = new EstimatorChain<TLastTransformer>();
-            _transformerChain = new TransformerChain<TLastTransformer>();
+
         }
 
-        public TrivialEstimatorChain<TNewTrans> Append<TTrivialEstimator, TNewTrans>(TTrivialEstimator estimator, TransformerScope scope = TransformerScope.Everything)
-            where TTrivialEstimator : class, IEstimator<TNewTrans>, TNewTrans
-            where TNewTrans : class, ITransformer
-            => new TrivialEstimatorChain<TNewTrans>(_host, _estimatorChain.Append(estimator, scope), _transformerChain.Append(estimator as TNewTrans));
+        public TrivialEstimatorChain<ITransformer> Append<TTrivialEstimator>(TTrivialEstimator estimator, TransformerScope scope = TransformerScope.Everything)
+            where TTrivialEstimator : class, IEstimator<ITransformer>, ITransformer
+            => new TrivialEstimatorChain<ITransformer>(_host, _estimatorChain.Append(estimator, scope), _transformerChain.Append(estimator as ITransformer));
 
         public EstimatorChain<TNewTrans> Append<TNewTrans>(IEstimator<TNewTrans> estimator, TransformerScope scope = TransformerScope.Everything)
             where TNewTrans : class, ITransformer
@@ -68,13 +62,13 @@ namespace Microsoft.ML.Data
         public SchemaShape GetOutputSchema(SchemaShape inputSchema)
             => _estimatorChain.GetOutputSchema(inputSchema);
 
-        bool ITransformer.IsRowToRowMapper => ((ITransformer)_transformerChain).IsRowToRowMapper;
-
-        DataViewSchema ITransformer.GetOutputSchema(DataViewSchema inputSchema)
+        public DataViewSchema GetOutputSchema(DataViewSchema inputSchema)
             => _transformerChain.GetOutputSchema(inputSchema);
 
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)_transformerChain).IsRowToRowMapper;
+
         IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
-            => ((ITransformer)_transformerChain).GetRowToRowMapper(inputSchema);
+           => ((ITransformer)_transformerChain).GetRowToRowMapper(inputSchema);
 
         void ICanSaveModel.Save(ModelSaveContext ctx)
             => ((ITransformer)_transformerChain).Save(ctx);

--- a/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimatorChain.cs
+++ b/src/Microsoft.ML.Data/DataLoadSave/TrivialEstimatorChain.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Runtime;
+
+namespace Microsoft.ML.Data
+{
+    public sealed class TrivialEstimatorChain<TLastTransformer> : IEstimator<TransformerChain<TLastTransformer>>, ITransformer
+        where TLastTransformer : class, ITransformer
+    {
+        private readonly IHost _host;
+        private readonly EstimatorChain<TLastTransformer> _estimatorChain;
+        private readonly TransformerChain<TLastTransformer> _transformerChain;
+
+        private TrivialEstimatorChain(IHostEnvironment env, EstimatorChain<TLastTransformer> estimatorChain, TransformerChain<TLastTransformer> transformerChain)
+        {
+            Contracts.CheckValue(env, nameof(env));
+            _host = env.Register(nameof(TrivialEstimatorChain<TLastTransformer>));
+
+            _host.CheckValue(estimatorChain, nameof(estimatorChain));
+            _host.CheckValue(transformerChain, nameof(transformerChain));
+
+            _estimatorChain = estimatorChain;
+            _transformerChain = transformerChain;
+        }
+
+        /// <summary>
+        /// Create an empty estimator chain.
+        /// </summary>
+        public TrivialEstimatorChain()
+        {
+            _host = null;
+            _estimatorChain = new EstimatorChain<TLastTransformer>();
+            _transformerChain = new TransformerChain<TLastTransformer>();
+        }
+
+        public TrivialEstimatorChain<TNewTrans> Append<TTrivialEstimator, TNewTrans>(TTrivialEstimator estimator, TransformerScope scope = TransformerScope.Everything)
+            where TTrivialEstimator : class, IEstimator<TNewTrans>, TNewTrans
+            where TNewTrans : class, ITransformer
+            => new TrivialEstimatorChain<TNewTrans>(_host, _estimatorChain.Append(estimator, scope), _transformerChain.Append(estimator as TNewTrans));
+
+        public EstimatorChain<TNewTrans> Append<TNewTrans>(IEstimator<TNewTrans> estimator, TransformerScope scope = TransformerScope.Everything)
+            where TNewTrans : class, ITransformer
+            => _estimatorChain.Append(estimator, scope);
+        // REVIEW: Should we also allow ITransformer to be appended to the TrivialEstimatorChain thereby producing a TransformerChain?
+
+        /// <summary>
+        /// Append a 'caching checkpoint' to the estimator chain. This will ensure that the downstream estimators will be trained against
+        /// cached data. It is helpful to have a caching checkpoint before trainers that take multiple data passes.
+        /// </summary>
+        /// <param name="env">The host environment to use for caching.</param>
+        public TrivialEstimatorChain<TLastTransformer> AppendCacheCheckpoint(IHostEnvironment env)
+            => new TrivialEstimatorChain<TLastTransformer>(env, _estimatorChain.AppendCacheCheckpoint(env), _transformerChain);
+
+        public TransformerChain<TLastTransformer> Fit(IDataView input)
+        {
+            _host.CheckValue(input, nameof(input));
+            return _transformerChain;
+        }
+
+        public IDataView Transform(IDataView input)
+        {
+            _host.CheckValue(input, nameof(input));
+            return _transformerChain.Transform(input);
+        }
+
+        public SchemaShape GetOutputSchema(SchemaShape inputSchema)
+            => _estimatorChain.GetOutputSchema(inputSchema);
+
+        bool ITransformer.IsRowToRowMapper => ((ITransformer)_transformerChain).IsRowToRowMapper;
+
+        DataViewSchema ITransformer.GetOutputSchema(DataViewSchema inputSchema)
+            => _transformerChain.GetOutputSchema(inputSchema);
+
+        IRowToRowMapper ITransformer.GetRowToRowMapper(DataViewSchema inputSchema)
+            => ((ITransformer)_transformerChain).GetRowToRowMapper(inputSchema);
+
+        void ICanSaveModel.Save(ModelSaveContext ctx)
+            => ((ITransformer)_transformerChain).Save(ctx);
+    }
+}

--- a/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
+++ b/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.ML.Data;
+using Microsoft.ML.TestFramework;
+using Microsoft.ML.Transforms;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.ML.Tests
+{
+    public class TrivialEstimatorTransformerTests : BaseTestClass
+    {
+        public TrivialEstimatorTransformerTests(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        void SimpleTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "NFL" , Age = 14 },
+                new DataPoint() { Category = "NFL" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLS" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define a TrivialEstimator and Transform data.
+            var transformedData = mlContext.Transforms.CopyColumns("CopyAge", "Age").Transform(data);
+
+            // Inspect output and check that it actually transforms data.
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach(var outDataPoint in outEnum)
+                Assert.True(outDataPoint.CopyAge != 0);
+        }
+
+        [Fact]
+        void TrivialEstimatorChainsTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define a TrivialEstimatorChain by appending two TrivialEstimators.
+            var trivialEstimatorChain = mlContext.Transforms.CopyColumns("CopyAge", "Age")
+                .Append(mlContext.Transforms.CopyColumns("CopyCategory", "Category"));
+
+            // Transform data directly.
+            var transformedData = trivialEstimatorChain.Transform(data);
+
+            // Inspect output and check that it actually transforms data.
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach (var outDataPoint in outEnum)
+            {
+                Assert.True(outDataPoint.CopyAge != 0);
+                Assert.True(outDataPoint.CopyCategory == "MLB");
+            }
+        }
+
+
+        [Fact]
+        void EstimatorChainsTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            // Define same TrivialEstimatorChain by appending two TrivialEstimators.
+            var trivialEstimatorChain = mlContext.Transforms.CopyColumns("CopyAge", "Age")
+                .Append(mlContext.Transforms.CopyColumns("CopyCategory", "Category"));
+            
+            // Check that this is TrivialEstimatorChain and that I can transform data directly.
+            Assert.True(trivialEstimatorChain is TrivialEstimatorChain<ColumnCopyingTransformer>);
+            var transformedData = trivialEstimatorChain.Transform(data);
+
+            // Append a non trivial estimator to the chain.
+            var estimatorChain = trivialEstimatorChain.Append(mlContext.Transforms.Categorical.OneHotEncoding("OneHotAge", "Age"));
+
+            // The below gives an ERROR since the type becomes EstimatorChain as OneHotEncoding is not a trivial estimator. Uncomment to check!
+            //transformedData = estimatorChain.Transform(data);
+            Assert.True(estimatorChain is EstimatorChain<OneHotEncodingTransformer>);
+
+            // Use .Fit() and .Transform() to transform data after training the transform.
+            transformedData = estimatorChain.Fit(data).Transform(data);
+
+            // Check that adding a TrivialEstimator does not bring us back to a TrivialEstimatorChain since we have a trainable transform.
+            var newEstimatorChain = estimatorChain.Append(mlContext.Transforms.CopyColumns("CopyOneHotAge", "OneHotAge"));
+
+            // The below gives an ERROR since the type stays EstimatorChain as there is non trivial estimator in the chain. Uncomment to check!
+            //transformedData = newEstimatorChain.Transform(data);
+            Assert.True(newEstimatorChain is EstimatorChain<ColumnCopyingTransformer>);
+
+            // Use .Fit() and .Transform() to transform data after training the transform.
+            transformedData = newEstimatorChain.Fit(data).Transform(data);
+
+            // Check that the data has actually been transformed
+            var outEnum = mlContext.Data.CreateEnumerable<OutDataPoint>(transformedData, true, true);
+            foreach (var outDataPoint in outEnum)
+            {
+                Assert.True(outDataPoint.CopyAge != 0);
+                Assert.True(outDataPoint.CopyCategory == "MLB");
+                Assert.NotNull(outDataPoint.OneHotAge);
+                Equals(outDataPoint.CopyOneHotAge, outDataPoint.OneHotAge);
+            }
+
+        }
+
+        [Fact]
+        void TrivialEstimatorChainWorkoutTest()
+        {
+            // Get a small dataset as an IEnumerable.
+            var rawData = new[] {
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+                new DataPoint() { Category = "MLB" , Age = 15 },
+                new DataPoint() { Category = "MLB" , Age = 18 },
+                new DataPoint() { Category = "MLB" , Age = 14 },
+            };
+
+            // Load the data from enumerable.
+            var mlContext = new MLContext();
+            var data = mlContext.Data.LoadFromEnumerable(rawData);
+
+            var trivialEstiamtorChain = new TrivialEstimatorChain<ITransformer>();
+            var estimatorChain = new EstimatorChain<ITransformer>();
+
+            var transformedData1 = trivialEstiamtorChain.Transform(data);
+            var transformedData2 = estimatorChain.Fit(data).Transform(data);
+
+            Assert.Equal(transformedData1.Schema.Count, transformedData2.Schema.Count);
+            Assert.True(transformedData1.Schema.Count == 2);
+        }
+
+        private class DataPoint
+        {
+            public string Category { get; set; }
+            public uint Age { get; set; }
+        }
+
+        private class OutDataPoint
+        {
+            public string Category { get; set; }
+            public string CopyCategory { get; set; }
+            public uint Age { get; set; }
+            public uint CopyAge { get; set; }
+            public float[] OneHotAge { get; set; }
+            public float[] CopyOneHotAge { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
+++ b/test/Microsoft.ML.Tests/TrivialEstimatorTransformerTests.cs
@@ -94,9 +94,9 @@ namespace Microsoft.ML.Tests
             // Define same TrivialEstimatorChain by appending two TrivialEstimators.
             var trivialEstimatorChain = mlContext.Transforms.CopyColumns("CopyAge", "Age")
                 .Append(mlContext.Transforms.CopyColumns("CopyCategory", "Category"));
-            
+
             // Check that this is TrivialEstimatorChain and that I can transform data directly.
-            Assert.True(trivialEstimatorChain is TrivialEstimatorChain<ColumnCopyingTransformer>);
+            Assert.True(trivialEstimatorChain is TrivialEstimatorChain<ITransformer>);
             var transformedData = trivialEstimatorChain.Transform(data);
 
             // Append a non trivial estimator to the chain.


### PR DESCRIPTION
I am a bit concerned about the fact that we have to .Fit(...) for non trainable transforms. I think it can make ML.NET look really bad! I worked on a solution for the problem...

I tried three approaches:

1. Create a new interface that combines IEstimator and ITransformer:ITrivialEstiamtor<TTransformer> : IEstimator<TTransformer> , ITransformer
2. Make the trivial estimator class implement ITransformer:TrivialEstimator<TTransformer> : IEstimator<TTransformer>, ITransformer
3. Simply add a method .Transform(IDataView input) in  the TrivialEstimator class.

For each one of these the difficult part is making sure that the estimator/transformer chains work properly. So I implemented a TrivialEstiamtorChain that mimics EstimatorChain but on the class TrivialEstimator instead of the interface IEstimator.

For 1. and 2. I did not manage to make it work... When you .Append() two trivialestimators it will just have a difficult time to distinguish whether you want to create a new EstimatorChain or a TransformerChain. 

For 3. I managed to make it work, I think! The .Append() works and will switch to an EstimatorChain as soon as a trainable estimator is added to the pipeline.

Is it fine not having a class/interface that combines ITransformer and IEstimator?


